### PR TITLE
Unify the format and order of supported platforms

### DIFF
--- a/wiki/cave-editor.md
+++ b/wiki/cave-editor.md
@@ -2,7 +2,7 @@
 
 <fieldset>
 <legend>Cave Editor:</legend>
-<img src="img\editors\ce-assets\CE_icon.png">
+<img src="/wiki/img/editors/ce-assets/CE_icon.png">
 <table><tbody>
 
 

--- a/wiki/cse2.md
+++ b/wiki/cse2.md
@@ -7,7 +7,7 @@
 
 <tr><td>Creator(s):</td><td>Clownacy Et al.</td></tr>
 <tr><td>Year:</td><td>2019</td></tr>
-<tr><td>Platform:</td><td>Mac OS, Linux OS, Windows OS</td></tr>
+<tr><td>Platform:</td><td>Windows, Mac, Linux</td></tr>
 <tr><td>Status:</td><td>
 <p style="color:#B00000;">DMCA'd</p>
 </td></tr>

--- a/wiki/csr.md
+++ b/wiki/csr.md
@@ -7,7 +7,7 @@
 
 <tr><td>Creator(s):</td><td>Gabriel, SlightlyIntelligentMonkey, et.al</td></tr>
 <tr><td>Year:</td><td>2018</td></tr>
-<tr><td>Platform:</td><td>Mac OS, Linux OS, Windows OS</td></tr>
+<tr><td>Platform:</td><td>Windows, Mac, Linux</td></tr>
 <tr><td>Status:</td><td>
 <p style="color:#B00000;">Abandoned</p>
 </td></tr>

--- a/wiki/dou-asm.md
+++ b/wiki/dou-asm.md
@@ -7,7 +7,7 @@
 
 <tr><td>Creator:</td><td>Carrotlord</td></tr>
 <tr><td>Year (Newest):</td><td>2010</td></tr>
-<tr><td>Platform:</td><td>Windows OS, Mac OS, Linux OS (Java)</td></tr>
+<tr><td>Platform:</td><td>Windows, Mac, Linux (Java)</td></tr>
 <tr><td>Status:</td><td>
 <p style="color:#B0B000;">Stale</p>
 </td></tr>

--- a/wiki/doukutsu-rs.md
+++ b/wiki/doukutsu-rs.md
@@ -10,7 +10,7 @@
 
 <tr><td>Creator(s):</td><td>Alula Et al.</td></tr>
 <tr><td>Year:</td><td>2021</td></tr>
-<tr><td>Platform:</td><td>Mac, Linux, Windows, Android</td></tr>
+<tr><td>Platform:</td><td>Windows, Mac, Linux, Android</td></tr>
 <tr><td>Status:</td><td>
 <p style="color:#00B000;">Active development</p>
 </td></tr>

--- a/wiki/nx-engine.md
+++ b/wiki/nx-engine.md
@@ -10,7 +10,7 @@
 
 <tr><td>Creator(s):</td><td>Caitlin Shaw, isage</td></tr>
 <tr><td>Year:</td><td>2010</td></tr>
-<tr><td>Platform:</td><td>Mac, Linux, Windows, RetroArch, SEGA Genesis, Others</td></tr>
+<tr><td>Platform:</td><td>Windows, Mac, Linux, RetroArch, SEGA Genesis, Others</td></tr>
 <tr><td>Status:</td><td>
 <p style="color: #B0B000;">Stale</p>
 </td></tr>

--- a/wiki/ollydbg.md
+++ b/wiki/ollydbg.md
@@ -7,7 +7,7 @@
 
 <tr><td>Creator:</td><td>Oleh "Olly" Yuschuk</td></tr>
 <tr><td>Year (Newest):</td><td>2014</td></tr>
-<tr><td>Platform:</td><td>Windows OS</td></tr>
+<tr><td>Platform:</td><td>Windows</td></tr>
 <tr><td>Status:</td><td>
 <p style="color:#B0B000;">Stale</p>
 </td></tr>


### PR DESCRIPTION
The names "Windows" and "Linux" without the "OS" suffix are more commonly used. "Mac OS" was replaced with "Mac" just because it looks better in sentences like “Mac/Linux with Wine”.